### PR TITLE
fix(huks): session slot leak, blob length check, and HuksBlob use

### DIFF
--- a/crates/huks/src/key.rs
+++ b/crates/huks/src/key.rs
@@ -79,9 +79,13 @@ impl<'a> HuksAlias<'a> {
     }
 
     /// Import raw key material under this alias.
-    pub fn import(self, params: &ParamSet, key_material: &[u8]) -> Result<()> {
+    pub fn import<'m>(
+        self,
+        params: &ParamSet,
+        key_material: impl Into<HuksBlob<'m>>,
+    ) -> Result<()> {
         let alias = self.to_raw()?;
-        let key = HuksBlob::new(key_material).to_raw()?;
+        let key = key_material.into().to_raw()?;
         // SAFETY: all three blobs are valid for the duration of the call.
         unsafe { check(OH_Huks_ImportKeyItem(&alias, params.as_ptr(), &key)) }
     }

--- a/crates/huks/src/param.rs
+++ b/crates/huks/src/param.rs
@@ -138,8 +138,14 @@ impl ParamSetBuilder {
             HuksValue::Ulong(v) => param.__bindgen_anon_1.uint64Param = v,
             HuksValue::Bytes(bytes) => {
                 let mut owned = bytes;
+                let Ok(size) = u32::try_from(owned.len()) else {
+                    self.error = Some(HuksError::illegal_argument(
+                        "blob length does not fit in OH_Huks_Blob::size",
+                    ));
+                    return self;
+                };
                 param.__bindgen_anon_1.blob = OH_Huks_Blob {
-                    size: owned.len() as u32,
+                    size,
                     data: owned.as_mut_ptr(),
                 };
                 // Moving `owned` into the Vec keeps its heap buffer address stable, so

--- a/crates/huks/src/session.rs
+++ b/crates/huks/src/session.rs
@@ -66,10 +66,15 @@ impl Session {
     }
 
     /// Feed a chunk of input; returns any output produced so far.
-    pub fn update(&mut self, params: &ParamSet, input: &[u8]) -> Result<Vec<u8>> {
+    pub fn update<'i>(
+        &mut self,
+        params: &ParamSet,
+        input: impl Into<HuksBlob<'i>>,
+    ) -> Result<Vec<u8>> {
+        let input = input.into();
         let handle = HuksBlob::new(&self.handle).to_raw()?;
-        let input_blob = HuksBlob::new(input).to_raw()?;
-        let mut buf = Self::out_buf(input.len() + 64);
+        let input_blob = input.to_raw()?;
+        let mut buf = Self::out_buf(input.as_bytes().len() + 64);
         let mut out = OH_Huks_Blob {
             size: buf.len() as u32,
             data: buf.as_mut_ptr(),
@@ -89,11 +94,18 @@ impl Session {
 
     /// Finish the session with a final input chunk; returns the final output
     /// (ciphertext / plaintext / signature / mac). Consumes the session.
-    pub fn finish(mut self, params: &ParamSet, input: &[u8]) -> Result<Vec<u8>> {
-        self.done = true;
+    pub fn finish<'i>(
+        mut self,
+        params: &ParamSet,
+        input: impl Into<HuksBlob<'i>>,
+    ) -> Result<Vec<u8>> {
+        let input = input.into();
         let handle = HuksBlob::new(&self.handle).to_raw()?;
-        let input_blob = HuksBlob::new(input).to_raw()?;
-        let mut buf = Self::out_buf(input.len() + 64);
+        let input_blob = input.to_raw()?;
+        // Only now that nothing can fail before the call: the native side ends the
+        // session whether or not it succeeds, so Drop must not abort it again.
+        self.done = true;
+        let mut buf = Self::out_buf(input.as_bytes().len() + 64);
         let mut out = OH_Huks_Blob {
             size: buf.len() as u32,
             data: buf.as_mut_ptr(),


### PR DESCRIPTION
Three fixes to the HUKS bindings merged in #125.

1. `Session::finish` set `done = true` before the fallible `to_raw`, so a blob
   longer than `u32::MAX` returned early and `Drop` then skipped the best-effort
   abort — leaking the native session slot the type's own docs promise to
   release. Moved the flag past both conversions, to just before the FFI call
   the native side ends the session with regardless of outcome.

2. `ParamSetBuilder::add` truncated a byte parameter's length with `as u32`,
   while every other blob path was switched to a real error in #125. Made it
   consistent, through the builder's existing deferred error.

3. `HuksBlob` was exported and documented as the byte-input type but nothing
   public accepted it. `import` / `Session::update` / `Session::finish` now take
   `impl Into<HuksBlob<'_>>`; `&[u8]` still passes directly through the existing
   `From` impl.

fmt + clippy, three targets, default and `--all-features`.
