### PR TITLE
fix(ime): deliver private commands instead of an empty leftover Vec

### DIFF
--- a/crates/ime/src/proxy/mod.rs
+++ b/crates/ime/src/proxy/mod.rs
@@ -10,8 +10,10 @@ use crate::{
 };
 
 mod callbacks;
+mod private_command_array;
 
 pub use callbacks::*;
+use private_command_array::collect_private_commands;
 
 fn char16_ptr_to_string(ptr: *const u16, length: usize) -> String {
     let mut result = String::new();
@@ -182,14 +184,8 @@ pub unsafe extern "C" fn receive_private_command(
         .expect("Failed to acquire read lock");
     if let Some(f) = &guard.receive_private_command {
         unsafe {
-            let slice = std::slice::from_raw_parts_mut(command, len);
-
-            let mut manual_array = Vec::new();
-            for (i, command) in manual_array.iter_mut().enumerate().take(len) {
-                *command = PrivateCommand {
-                    raw: *slice.get_unchecked(i),
-                };
-            }
+            let slice = std::slice::from_raw_parts(command, len);
+            let manual_array = collect_private_commands(slice, |raw| PrivateCommand { raw });
             f(manual_array);
         }
     }

--- a/crates/ime/src/proxy/private_command_array.rs
+++ b/crates/ime/src/proxy/private_command_array.rs
@@ -1,0 +1,37 @@
+/// Copy NDK private-command pointers into wrappers.
+///
+/// This helper only copies pointers and does not call NDK APIs, so it can be
+/// unit-tested on the host with dummy pointers.
+pub(crate) fn collect_private_commands<T, W>(
+    commands: &[*mut T],
+    wrap: impl Fn(*mut T) -> W,
+) -> Vec<W> {
+    commands.iter().copied().map(wrap).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_private_commands_copies_two_dummy_pointers() {
+        let mut first = 0u8;
+        let mut second = 1u8;
+        let commands = [&mut first as *mut u8, &mut second as *mut u8];
+
+        let wrapped = collect_private_commands(&commands, |raw| raw);
+
+        assert_eq!(wrapped.len(), 2);
+        assert_eq!(wrapped[0], commands[0]);
+        assert_eq!(wrapped[1], commands[1]);
+    }
+
+    #[test]
+    fn collect_private_commands_empty_len_is_empty() {
+        let commands: [*mut u8; 0] = [];
+
+        let wrapped = collect_private_commands(&commands, |raw| raw);
+
+        assert_eq!(wrapped.len(), 0);
+    }
+}


### PR DESCRIPTION
`receive_private_command` built `Vec::new()` and then iterated `manual_array.iter_mut()`, so the leftover loop never ran. The IME callback always got `[]` even when `len > 0`, and private commands were silently dropped.

Fix copies the NDK pointer slice into wrappers. The helper does not call NDK APIs, so it is host-tested: `len=2` dummy pointers produce 2 items; empty produces 0.

Does not change UTF-16 decode (`char16_ptr_to_string`) or the sensor crate.

Signed-off-by: Tony Coder <407243179@qq.com>
