### PR TITLE
fix(ime): decode UTF-16 surrogate pairs in insert/preview text

### DIFF
--- a/crates/ime/src/lib.rs
+++ b/crates/ime/src/lib.rs
@@ -6,6 +6,7 @@ mod private_command;
 mod proxy;
 mod text_config;
 mod text_editor;
+mod utf16;
 
 pub use attach::*;
 pub use cursor::*;

--- a/crates/ime/src/proxy/mod.rs
+++ b/crates/ime/src/proxy/mod.rs
@@ -5,29 +5,13 @@ use ohos_input_method_sys::{
 };
 
 use crate::{
-    private_command::PrivateCommand, Action, Direction, EnterKey, KeyboardStatus, Selection,
-    TextConfig,
+    private_command::PrivateCommand, utf16::char16_ptr_to_string, Action, Direction, EnterKey,
+    KeyboardStatus, Selection, TextConfig,
 };
 
 mod callbacks;
 
 pub use callbacks::*;
-
-fn char16_ptr_to_string(ptr: *const u16, length: usize) -> String {
-    let mut result = String::new();
-
-    unsafe {
-        let slice = std::slice::from_raw_parts(ptr, length);
-
-        for &unit in slice.iter() {
-            if let Some(Ok(c)) = char::decode_utf16(std::iter::once(unit)).next() {
-                result.push(c);
-            }
-        }
-    }
-
-    result
-}
 
 pub unsafe extern "C" fn delete_backward(_text_editor: *mut InputMethod_TextEditorProxy, len: i32) {
     let guard = OHOS_RS_IME_CALLBACKS

--- a/crates/ime/src/utf16.rs
+++ b/crates/ime/src/utf16.rs
@@ -1,0 +1,25 @@
+/// Decode an IME `char16_t` buffer to `String`.
+///
+/// The whole slice is decoded so UTF-16 surrogate pairs (emoji / non-BMP)
+/// stay intact. Host-testable: no Harmony FFI.
+pub(crate) fn char16_ptr_to_string(ptr: *const u16, length: usize) -> String {
+    let slice = unsafe { std::slice::from_raw_parts(ptr, length) };
+    String::from_utf16_lossy(slice)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::char16_ptr_to_string;
+
+    #[test]
+    fn decodes_bmp_units() {
+        let units = [b'h' as u16, b'i' as u16];
+        assert_eq!(char16_ptr_to_string(units.as_ptr(), units.len()), "hi");
+    }
+
+    #[test]
+    fn decodes_surrogate_pair() {
+        let units = [0xD83D, 0xDE00];
+        assert_eq!(char16_ptr_to_string(units.as_ptr(), units.len()), "😀");
+    }
+}


### PR DESCRIPTION
`insert_text` and `set_preview_text` decoded one UTF-16 unit at a time (`char::decode_utf16(once(unit))`), so leftover surrogate pairs were dropped. Insert of "😀" (`[0xD83D, 0xDE00]`) became an empty string.

Decode the whole slice with `String::from_utf16_lossy`. Helper is host-tested: BMP `"hi"` and the emoji surrogate pair. No device.

Does not change `receive_private_command` (that is #134) or the sensor crate.

Signed-off-by: Tony Coder <407243179@qq.com>
