### PR TITLE
fix(resource_manager): adopt NDK media buffers instead of leftover empty Vec

### DIFF
--- a/crates/resource_manager/Cargo.toml
+++ b/crates/resource_manager/Cargo.toml
@@ -27,3 +27,4 @@ api-20 = ["api-19", "ohos-resource-manager-sys/api-20"]
 [dependencies]
 ohos-resource-manager-sys = { workspace = true }
 napi-ohos                 = { workspace = true, optional = true }
+libc                      = { workspace = true }

--- a/crates/resource_manager/src/lib.rs
+++ b/crates/resource_manager/src/lib.rs
@@ -5,6 +5,7 @@ use ohos_resource_manager_sys::{
     OH_ResourceManager_GetMediaByName, ResourceManager_ErrorCode_SUCCESS,
 };
 use std::ffi::CString;
+use std::os::raw::c_char;
 use std::ptr;
 
 use std::ptr::NonNull;
@@ -21,11 +22,14 @@ use ohos_resource_manager_sys::{
 
 mod error;
 mod info;
+mod media_buffer;
 mod raw_dir;
 
 pub use error::*;
 pub use info::*;
 pub use raw_dir::*;
+
+use media_buffer::adopt_ndk_media_buffer;
 
 /// Resource Manager
 pub struct ResourceManager {
@@ -155,20 +159,20 @@ impl ResourceManager {
         res_id: u32,
         density: Option<ScreenDensity>,
     ) -> Result<Vec<u8>, RawFileError> {
-        let mut ret: Vec<u8> = Vec::new();
-        let mut len = 0;
+        let mut ptr: *mut u8 = ptr::null_mut();
+        let mut len = 0u64;
         let use_density = density.unwrap_or_default();
         let code = unsafe {
             OH_ResourceManager_GetMedia(
                 self.resource_manager.as_ptr(),
                 res_id,
-                ret.as_mut_ptr().cast(),
+                &mut ptr,
                 &mut len,
                 use_density.into(),
             )
         };
         if code == ResourceManager_ErrorCode_SUCCESS {
-            Ok(ret)
+            Ok(unsafe { take_ndk_media_buffer(ptr, len) })
         } else {
             Err(RawFileError::FfiInnerError(format!(
                 "Media failed: {}",
@@ -182,20 +186,20 @@ impl ResourceManager {
         res_id: u32,
         density: Option<ScreenDensity>,
     ) -> Result<Vec<u8>, RawFileError> {
-        let mut ret: Vec<u8> = Vec::new();
-        let mut len = 0;
+        let mut ptr: *mut c_char = ptr::null_mut();
+        let mut len = 0u64;
         let use_density = density.unwrap_or_default();
         let code = unsafe {
             OH_ResourceManager_GetMediaBase64(
                 self.resource_manager.as_ptr(),
                 res_id,
-                ret.as_mut_ptr().cast(),
+                &mut ptr,
                 &mut len,
                 use_density.into(),
             )
         };
         if code == ResourceManager_ErrorCode_SUCCESS {
-            Ok(ret)
+            Ok(unsafe { take_ndk_media_buffer(ptr.cast(), len) })
         } else {
             Err(RawFileError::FfiInnerError(format!(
                 "Media base64 failed: {}",
@@ -209,8 +213,8 @@ impl ResourceManager {
         name: String,
         density: Option<ScreenDensity>,
     ) -> Result<Vec<u8>, RawFileError> {
-        let mut ret: Vec<u8> = Vec::new();
-        let mut len = 0;
+        let mut ptr: *mut u8 = ptr::null_mut();
+        let mut len = 0u64;
         let use_density = density.unwrap_or_default();
         let use_name = CString::new(name).expect("Create CString failed");
 
@@ -218,13 +222,13 @@ impl ResourceManager {
             OH_ResourceManager_GetMediaByName(
                 self.resource_manager.as_ptr(),
                 use_name.as_ptr().cast(),
-                ret.as_mut_ptr().cast(),
+                &mut ptr,
                 &mut len,
                 use_density.into(),
             )
         };
         if code == ResourceManager_ErrorCode_SUCCESS {
-            Ok(ret)
+            Ok(unsafe { take_ndk_media_buffer(ptr, len) })
         } else {
             Err(RawFileError::FfiInnerError(format!(
                 "Media by name failed: {}",
@@ -238,8 +242,8 @@ impl ResourceManager {
         name: String,
         density: Option<ScreenDensity>,
     ) -> Result<Vec<u8>, RawFileError> {
-        let mut ret: Vec<u8> = Vec::new();
-        let mut len = 0;
+        let mut ptr: *mut c_char = ptr::null_mut();
+        let mut len = 0u64;
         let use_density = density.unwrap_or_default();
         let use_name = CString::new(name).expect("Create CString failed");
 
@@ -247,13 +251,13 @@ impl ResourceManager {
             OH_ResourceManager_GetMediaBase64ByName(
                 self.resource_manager.as_ptr(),
                 use_name.as_ptr().cast(),
-                ret.as_mut_ptr().cast(),
+                &mut ptr,
                 &mut len,
                 use_density.into(),
             )
         };
         if code == ResourceManager_ErrorCode_SUCCESS {
-            Ok(ret)
+            Ok(unsafe { take_ndk_media_buffer(ptr.cast(), len) })
         } else {
             Err(RawFileError::FfiInnerError(format!(
                 "Media base64 by name failed: {}",
@@ -261,6 +265,16 @@ impl ResourceManager {
             )))
         }
     }
+}
+
+/// Adopt an NDK-allocated media buffer: copy into a Rust `Vec`, then free
+/// the malloc'd pointer. Do not use `Vec::from_raw_parts` (allocator mismatch).
+unsafe fn take_ndk_media_buffer(ptr: *mut u8, len: u64) -> Vec<u8> {
+    let bytes = adopt_ndk_media_buffer(ptr, len);
+    if !ptr.is_null() {
+        libc::free(ptr.cast());
+    }
+    bytes
 }
 
 unsafe impl Send for ResourceManager {}

--- a/crates/resource_manager/src/media_buffer.rs
+++ b/crates/resource_manager/src/media_buffer.rs
@@ -1,0 +1,38 @@
+/// Copy an NDK media out-buffer into a Rust `Vec`.
+///
+/// `OH_ResourceManager_GetMedia*` writes `resultValue: *mut *mut u8`
+/// (or `*mut *mut c_char` for base64) and allocates with malloc. This
+/// helper only copies bytes and does not call NDK APIs, so it can be
+/// unit-tested on the host with dummy pointers. The caller must free the
+/// NDK allocation with `libc::free` after a successful non-empty adopt.
+/// Do not use `Vec::from_raw_parts` on the NDK pointer (allocator mismatch).
+///
+/// # Safety
+///
+/// `ptr` must be null or point to at least `len` readable bytes.
+pub(crate) unsafe fn adopt_ndk_media_buffer(ptr: *const u8, len: u64) -> Vec<u8> {
+    if ptr.is_null() || len == 0 {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(ptr, len as usize).to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adopt_leftover_empty_null_len_zero_is_empty() {
+        let ret = unsafe { adopt_ndk_media_buffer(std::ptr::null(), 0) };
+        assert!(ret.is_empty());
+    }
+
+    #[test]
+    fn adopt_leftover_dummy_four_byte_buffer() {
+        let buf = [0xDEu8, 0xAD, 0xBE, 0xEF];
+        let ret = unsafe { adopt_ndk_media_buffer(buf.as_ptr(), 4) };
+        assert_eq!(ret.len(), 4);
+        assert_eq!(ret, [0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+}


### PR DESCRIPTION
`media` / `media_base64` / `media_by_name` / `media_base64_by_name` built `Vec::new()` and passed `ret.as_mut_ptr().cast()` into `OH_ResourceManager_GetMedia*`. The NDK signature is `resultValue: *mut *mut u8` (NDK allocates). The leftover empty-Vec pointer never adopted the buffer, so callers always got `[]` and the NDK allocation leaked.

Fix uses an out-pointer, copies into a Rust `Vec`, then `libc::free`. Do not `Vec::from_raw_parts` the NDK pointer (allocator mismatch). Helper is host-tested: null/len=0 is empty; a 4-byte dummy buffer is length 4.

Does not change IME (#134/#135), sensor, or asset.

Signed-off-by: Tony Coder <407243179@qq.com>
