### PR TITLE
fix(asset): drop leftover ManuallyDrop so copied query blobs free

### DIFF
--- a/crates/asset/src/blob.rs
+++ b/crates/asset/src/blob.rs
@@ -1,0 +1,38 @@
+pub type AssetBlob = Vec<u8>;
+
+pub enum AssetValue {
+    Boolean(bool),
+    U32IntT(u32),
+    Blob(Vec<u8>),
+}
+
+/// Copy native asset bytes into an owned `Vec<u8>`.
+///
+/// Query results are released by `OH_Asset_FreeResultSet`, so the binding
+/// must own the copy. Host-testable: no Harmony FFI.
+pub(crate) fn copy_asset_blob(data: *const u8, size: u32) -> Vec<u8> {
+    unsafe { std::slice::from_raw_parts(data, size as usize).to_vec() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{copy_asset_blob, AssetValue};
+
+    #[test]
+    fn copy_asset_blob_copies_dummy_bytes() {
+        let dummy = [1u8, 2, 3];
+        let copied = copy_asset_blob(dummy.as_ptr(), dummy.len() as u32);
+        assert_eq!(copied.len(), 3);
+        assert_eq!(copied, dummy);
+    }
+
+    #[test]
+    fn dropping_blob_frees_owned_vec() {
+        let value = AssetValue::Blob(vec![1, 2, 3]);
+        let AssetValue::Blob(bytes) = value else {
+            panic!("expected blob");
+        };
+        // Blob stores Vec<u8>, not ManuallyDrop, so Drop frees the copy.
+        let _: Vec<u8> = bytes;
+    }
+}

--- a/crates/asset/src/data.rs
+++ b/crates/asset/src/data.rs
@@ -1,14 +1,4 @@
-use std::mem::ManuallyDrop;
-
-use crate::AssetTag;
-
-pub type AssetBlob = Vec<u8>;
-
-pub enum AssetValue {
-    Boolean(bool),
-    U32IntT(u32),
-    Blob(ManuallyDrop<AssetBlob>),
-}
+use crate::{copy_asset_blob, AssetTag, AssetValue};
 
 pub struct AssetAttr {
     pub tag: AssetTag,
@@ -67,9 +57,7 @@ impl From<*mut ohos_asset_sys::Asset_Result> for AssetResult {
                         }
                         ohos_asset_sys::Asset_TagType_ASSET_TYPE_BYTES => {
                             let blob = raw_attr.value.blob;
-                            let data_slice =
-                                std::slice::from_raw_parts(blob.data, blob.size as usize);
-                            AssetValue::Blob(ManuallyDrop::new(data_slice.to_vec()))
+                            AssetValue::Blob(copy_asset_blob(blob.data, blob.size))
                         }
                         _ => unimplemented!(),
                     },
@@ -114,9 +102,7 @@ impl From<*mut ohos_asset_sys::Asset_ResultSet> for AssetResultSet {
                         }
                         ohos_asset_sys::Asset_TagType_ASSET_TYPE_BYTES => {
                             let blob = raw_attr.value.blob;
-                            let data_slice =
-                                std::slice::from_raw_parts(blob.data, blob.size as usize);
-                            AssetValue::Blob(ManuallyDrop::new(data_slice.to_vec()))
+                            AssetValue::Blob(copy_asset_blob(blob.data, blob.size))
                         }
                         _ => unimplemented!(),
                     };

--- a/crates/asset/src/lib.rs
+++ b/crates/asset/src/lib.rs
@@ -1,9 +1,11 @@
+mod blob;
 mod data;
 mod r#error;
 mod r#type;
 
 use std::ptr;
 
+pub use blob::*;
 pub use data::*;
 pub use r#error::*;
 pub use r#type::*;


### PR DESCRIPTION
`asset_query` copies native blob bytes with `to_vec()`, then `OH_Asset_FreeResultSet` frees the native set. Wrapping that owned `Vec<u8>` in `ManuallyDrop` prevented Drop, so every queried blob leaked until process exit.

`ManuallyDrop` was leftover from wrapping `from_raw_parts` on native data (so Drop would double-free after FreeResultSet). After switching to `to_vec()`, store `Blob(Vec<u8>)`.

Host-tested: dummy `[1,2,3]` copies length 3; `AssetValue::Blob` stores a `Vec`, not `ManuallyDrop`.

Does not change IME (#134/#135), sensor, or resource_manager (#136).

Signed-off-by: Tony Coder <407243179@qq.com>
